### PR TITLE
Exclude all subtrees in libs

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,8 +1,8 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->exclude('libs/phpseclib')
-    ->in(__DIR__);
+    ->in(__DIR__)
+    ->exclude('libs/phpseclib');
 
 return PhpCsFixer\Config::create()
     ->setRules([

--- a/.php_cs
+++ b/.php_cs
@@ -1,7 +1,7 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->exclude('/libs\/.*\/\.github/)
+    ->exclude('/libs\/.*\/\.github/')
     ->in(__DIR__);
 
 return PhpCsFixer\Config::create()

--- a/.php_cs
+++ b/.php_cs
@@ -1,7 +1,7 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->exclude('libs/vendor')
+    ->exclude('libs/phpseclib')
     ->in(__DIR__);
 
 return PhpCsFixer\Config::create()

--- a/.php_cs
+++ b/.php_cs
@@ -1,8 +1,8 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-    ->notPath('libs/phpseclib');
+    ->exclude('/libs\/.*\/\.github/)
+    ->in(__DIR__);
 
 return PhpCsFixer\Config::create()
     ->setRules([

--- a/.php_cs
+++ b/.php_cs
@@ -2,7 +2,7 @@
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
-    ->exclude('libs/phpseclib');
+    ->notPath('libs/phpseclib');
 
 return PhpCsFixer\Config::create()
     ->setRules([


### PR DESCRIPTION
'Finder' in config only work with the --path-mode=intersection argument.